### PR TITLE
Let IsConnectedViaWiFiOrUnknown behave as expected in demo app.

### DIFF
--- a/demo_app/src/main/AndroidManifest.xml
+++ b/demo_app/src/main/AndroidManifest.xml
@@ -2,6 +2,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     package="org.ligi.snackengage_demo">
 
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+
     <application
         android:allowBackup="true"
         android:icon="@mipmap/ic_launcher"


### PR DESCRIPTION
+ The `IsConnectedViaWiFiOrUnknown` snack condition is configured in
  `DefaultRateSnack`. Once the WIFI connection is turned off the snack should
  not be shown. Without granting the permission however the snack is still
  shown due to `ConnectivityAwareCondition.isConnectivityAware()`.