### PR TITLE
Use SDK 26 and support library v.26.0.2.

### DIFF
--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "org.ligi.snackengage"
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode 3
         versionName "0.3"
     }
@@ -20,8 +20,6 @@ android {
     }
 
     lintOptions {
-        ignore 'MinSdkTooLow'
-        ignore 'ExpiredTargetSdkVersion'
         ignore 'GradleDependency'
     }
 }

--- a/snackengage-amazonrate/build.gradle
+++ b/snackengage-amazonrate/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode version_code
         versionName version_name
     }
@@ -20,8 +20,6 @@ android {
 
     lintOptions {
         baseline file("../.ci/lint-baseline-amazonrate.xml")
-        ignore 'MinSdkTooLow'
-        ignore 'ExpiredTargetSdkVersion'
         ignore 'NewerVersionAvailable'
         checkAllWarnings true
         warningsAsErrors true

--- a/snackengage-core/build.gradle
+++ b/snackengage-core/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode version_code
         versionName version_name
     }
@@ -20,8 +20,6 @@ android {
 
     lintOptions {
         baseline file("../.ci/lint-baseline-lib.xml")
-        ignore 'MinSdkTooLow'
-        ignore 'ExpiredTargetSdkVersion'
         ignore 'OldTargetApi'
         ignore 'NewerVersionAvailable'
         ignore 'GradleDependency'
@@ -32,7 +30,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:design:25.4.0'
+    compile 'com.android.support:design:26.0.2'
 
     testCompile 'com.squareup.assertj:assertj-android:1.2.0'
     testCompile 'com.android.support:support-annotations:25.4.0'

--- a/snackengage-playrate/build.gradle
+++ b/snackengage-playrate/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 25
+    compileSdkVersion 26
     buildToolsVersion "28.0.3"
 
     defaultConfig {
-        minSdkVersion 9
-        targetSdkVersion 25
+        minSdkVersion 14
+        targetSdkVersion 26
         versionCode version_code
         versionName version_name
     }
@@ -20,8 +20,6 @@ android {
 
     lintOptions {
         baseline file("../.ci/lint-baseline-playrate.xml")
-        ignore 'MinSdkTooLow'
-        ignore 'ExpiredTargetSdkVersion'
         ignore 'NewerVersionAvailable'
         checkAllWarnings true
         warningsAsErrors true


### PR DESCRIPTION
+ Version 26.0.0 of the support library raises the minSdkVersion to 14
  (Android 4.0, Ice Cream Sandwich).
+ Version 26.1.0 of the support library is not used here to avoid forcing
  users to inherit LifeCycle and Architecture Components. See:
  https://developer.android.com/topic/libraries/support-library/revisions#26-1-0
+ Remove unneeded Lint ignore rules.
+ [JitPack build log](https://jitpack.io/com/github/johnjohndoe/snackengage/5be50fcb30/build.log).