### PR TITLE
Use SDK 27 and support library v.27.1.1.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -6,8 +6,8 @@ buildscript {
         version_code = 18
     }
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 
     dependencies {
@@ -19,8 +19,8 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
         google()
+        jcenter()
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ buildscript {
 
     dependencies {
         classpath 'com.android.tools.build:gradle:3.2.1'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.20.0'
+        classpath 'com.github.ben-manes:gradle-versions-plugin:0.21.0'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
     }
 }

--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -26,5 +26,6 @@ android {
 }
 
 dependencies {
-    compile project(':snackengage-playrate')
+    implementation project(':snackengage-playrate')
+    implementation 'com.android.support:appcompat-v7:27.1.1'
 }

--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         applicationId "org.ligi.snackengage"
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode 3
         versionName "0.3"
     }

--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -20,6 +20,7 @@ android {
     }
 
     lintOptions {
+        ignore 'OldTargetApi'
         ignore 'GradleDependency'
     }
 }

--- a/snackengage-amazonrate/build.gradle
+++ b/snackengage-amazonrate/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode version_code
         versionName version_name
     }

--- a/snackengage-amazonrate/build.gradle
+++ b/snackengage-amazonrate/build.gradle
@@ -21,6 +21,7 @@ android {
     lintOptions {
         baseline file("../.ci/lint-baseline-amazonrate.xml")
         ignore 'NewerVersionAvailable'
+        ignore 'GradleDependency'
         checkAllWarnings true
         warningsAsErrors true
     }
@@ -28,6 +29,7 @@ android {
 }
 
 dependencies {
-    compile project(':snackengage-core')
+    api project(':snackengage-core')
+    implementation 'com.android.support:support-annotations:27.1.1'
 }
 

--- a/snackengage-core/build.gradle
+++ b/snackengage-core/build.gradle
@@ -30,11 +30,11 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:design:27.1.1'
+    implementation 'com.android.support:design:27.1.1'
 
-    testCompile 'com.squareup.assertj:assertj-android:1.2.0'
-    testCompile 'com.android.support:support-annotations:27.1.1'
-    testCompile 'junit:junit:4.12'
+    testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
+    testImplementation 'com.android.support:support-annotations:27.1.1'
+    testImplementation 'junit:junit:4.12'
 
-    testCompile 'org.mockito:mockito-core:2.25.0'
+    testImplementation 'org.mockito:mockito-core:2.25.0'
 }

--- a/snackengage-core/build.gradle
+++ b/snackengage-core/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode version_code
         versionName version_name
     }
@@ -30,10 +30,10 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:design:26.0.2'
+    compile 'com.android.support:design:27.1.1'
 
     testCompile 'com.squareup.assertj:assertj-android:1.2.0'
-    testCompile 'com.android.support:support-annotations:26.0.2'
+    testCompile 'com.android.support:support-annotations:27.1.1'
     testCompile 'junit:junit:4.12'
 
     testCompile 'org.mockito:mockito-core:2.25.0'

--- a/snackengage-core/build.gradle
+++ b/snackengage-core/build.gradle
@@ -36,5 +36,5 @@ dependencies {
     testCompile 'com.android.support:support-annotations:26.0.2'
     testCompile 'junit:junit:4.12'
 
-    testCompile 'org.mockito:mockito-core:2.23.0'
+    testCompile 'org.mockito:mockito-core:2.25.0'
 }

--- a/snackengage-core/build.gradle
+++ b/snackengage-core/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     compile 'com.android.support:design:26.0.2'
 
     testCompile 'com.squareup.assertj:assertj-android:1.2.0'
-    testCompile 'com.android.support:support-annotations:25.4.0'
+    testCompile 'com.android.support:support-annotations:26.0.2'
     testCompile 'junit:junit:4.12'
 
     testCompile 'org.mockito:mockito-core:2.23.0'

--- a/snackengage-core/src/test/java/org/ligi/snackengage/util/OpportunityIgnoringSnack.java
+++ b/snackengage-core/src/test/java/org/ligi/snackengage/util/OpportunityIgnoringSnack.java
@@ -12,6 +12,7 @@ public class OpportunityIgnoringSnack implements Snack {
         return false;
     }
 
+    @NonNull
     @Override
     public String uniqueId() {
         return "OPPORTUNITY_IGNORING";

--- a/snackengage-core/src/test/java/org/ligi/snackengage/util/OpportunityUsingSnack.java
+++ b/snackengage-core/src/test/java/org/ligi/snackengage/util/OpportunityUsingSnack.java
@@ -12,6 +12,7 @@ public class OpportunityUsingSnack implements Snack {
         return true;
     }
 
+    @NonNull
     @Override
     public String uniqueId() {
         return "OPPORTUNITY_USING";

--- a/snackengage-playrate/build.gradle
+++ b/snackengage-playrate/build.gradle
@@ -2,12 +2,12 @@ apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 26
+    compileSdkVersion 27
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 14
-        targetSdkVersion 26
+        targetSdkVersion 27
         versionCode version_code
         versionName version_name
     }

--- a/snackengage-playrate/build.gradle
+++ b/snackengage-playrate/build.gradle
@@ -21,6 +21,7 @@ android {
     lintOptions {
         baseline file("../.ci/lint-baseline-playrate.xml")
         ignore 'NewerVersionAvailable'
+        ignore 'GradleDependency'
         checkAllWarnings true
         warningsAsErrors true
     }
@@ -28,6 +29,7 @@ android {
 }
 
 dependencies {
-    compile project(':snackengage-core')
+    api project(':snackengage-core')
+    implementation 'com.android.support:support-annotations:27.1.1'
 }
 


### PR DESCRIPTION
# Description
- This branch prepares the library to be based on [SDK 27 (Android 8.1 Oreo)](https://developer.android.com/about/versions/oreo/android-8.1) and the corresponding [support library 27.1.1](https://developer.android.com/topic/libraries/support-library/revisions#27-1-1).
- [Log file](https://jitpack.io/com/github/johnjohndoe/snackengage/a10c3eec89/build.log) of the successful JitPack build for a10c3eec899f38c08c3f650ff0da3d1ff12750c1.
- This state should be released as version `0.19` to allow apps to gradually update.

# Further :house:  housekeeping
- Suppress Lint warning for not targeting the latest API.
- Deprioritze `jcenter` as the source for loading dependency artifacts.
- Add missing annotations derived from parent class method.
- Use gradle-versions-plugin v.0.21.0.
- Use mockito-core v.2.25.0.
- Update obsolete build configuration (`compile` -> `api` and `implementation`).