### PR TITLE
Organize project settings in "buildSrc" folder to simplify maintenance.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,19 +1,17 @@
+import static org.ligi.snackengage.Dependencies.GradlePlugins
+
 apply plugin: "com.github.ben-manes.versions"
 
 buildscript {
-    ext {
-        version_name = '0.24'
-        version_code = 24
-    }
     repositories {
         google()
         jcenter()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.6.3'
-        classpath 'com.github.ben-manes:gradle-versions-plugin:0.28.0'
-        classpath 'com.github.dcendents:android-maven-gradle-plugin:2.1'
+        classpath GradlePlugins.ANDROID
+        classpath GradlePlugins.MAVEN
+        classpath GradlePlugins.VERSIONS
     }
 }
 

--- a/buildSrc/src/main/java/org/ligi/snackengage/Dependencies.java
+++ b/buildSrc/src/main/java/org/ligi/snackengage/Dependencies.java
@@ -1,0 +1,36 @@
+package org.ligi.snackengage;
+
+public class Dependencies {
+
+    public static class Android {
+
+        public static final String APPLICATION_ID = "org.ligi.snackengage";
+        public static final String BUILD_TOOLS_VERSION = "29.0.3";
+        public static final int MIN_SDK_VERSION = 14;
+        public static final int COMPILE_SDK_VERSION = 28;
+        public static final int TARGET_SDK_VERSION = 28;
+        public static final int VERSION_CODE = 24;
+        public static final String VERSION_NAME = "0.24";
+
+    }
+
+    public static class GradlePlugins {
+
+        public static final String ANDROID = "com.android.tools.build:gradle:3.6.3";
+        public static final String MAVEN = "com.github.dcendents:android-maven-gradle-plugin:2.1";
+        public static final String VERSIONS = "com.github.ben-manes:gradle-versions-plugin:0.28.0";
+
+    }
+
+    public static class Libs {
+
+        public static final String ANNOTATION = "androidx.annotation:annotation:1.1.0";
+        public static final String APPCOMPAT = "androidx.appcompat:appcompat:1.1.0";
+        public static final String ASSERTJ_ANDROID = "com.squareup.assertj:assertj-android:1.2.0";
+        public static final String JUNIT = "junit:junit:4.13";
+        public static final String MATERIAL = "com.google.android.material:material:1.1.0";
+        public static final String MOCKITO = "org.mockito:mockito-core:3.3.0";
+
+    }
+
+}

--- a/demo_app/build.gradle
+++ b/demo_app/build.gradle
@@ -1,15 +1,18 @@
+import static org.ligi.snackengage.Dependencies.Android
+import static org.ligi.snackengage.Dependencies.Libs
+
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.3"
+    compileSdkVersion Android.COMPILE_SDK_VERSION
+    buildToolsVersion Android.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        applicationId "org.ligi.snackengage"
-        minSdkVersion 14
-        targetSdkVersion 28
-        versionCode 3
-        versionName "0.3"
+        applicationId Android.APPLICATION_ID
+        minSdkVersion Android.MIN_SDK_VERSION
+        targetSdkVersion Android.TARGET_SDK_VERSION
+        versionCode Android.VERSION_CODE
+        versionName Android.VERSION_NAME
     }
 
     buildTypes {
@@ -27,5 +30,5 @@ android {
 
 dependencies {
     implementation project(':snackengage-playrate')
-    implementation 'androidx.appcompat:appcompat:1.1.0'
+    implementation Libs.APPCOMPAT
 }

--- a/snackengage-amazonrate/build.gradle
+++ b/snackengage-amazonrate/build.gradle
@@ -1,15 +1,18 @@
+import static org.ligi.snackengage.Dependencies.Android
+import static org.ligi.snackengage.Dependencies.Libs
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.3"
+    compileSdkVersion Android.COMPILE_SDK_VERSION
+    buildToolsVersion Android.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 28
-        versionCode version_code
-        versionName version_name
+        minSdkVersion Android.MIN_SDK_VERSION
+        targetSdkVersion Android.TARGET_SDK_VERSION
+        versionCode Android.VERSION_CODE
+        versionName Android.VERSION_NAME
     }
     buildTypes {
         release {
@@ -30,6 +33,6 @@ android {
 
 dependencies {
     api project(':snackengage-core')
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation Libs.ANNOTATION
 }
 

--- a/snackengage-core/build.gradle
+++ b/snackengage-core/build.gradle
@@ -1,15 +1,18 @@
+import static org.ligi.snackengage.Dependencies.Android
+import static org.ligi.snackengage.Dependencies.Libs
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.3"
+    compileSdkVersion Android.COMPILE_SDK_VERSION
+    buildToolsVersion Android.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 28
-        versionCode version_code
-        versionName version_name
+        minSdkVersion Android.MIN_SDK_VERSION
+        targetSdkVersion Android.TARGET_SDK_VERSION
+        versionCode Android.VERSION_CODE
+        versionName Android.VERSION_NAME
     }
     buildTypes {
         release {
@@ -30,11 +33,11 @@ android {
 }
 
 dependencies {
-    implementation 'com.google.android.material:material:1.1.0'
+    implementation Libs.MATERIAL
 
-    testImplementation 'com.squareup.assertj:assertj-android:1.2.0'
-    testImplementation 'androidx.annotation:annotation:1.1.0'
-    testImplementation 'junit:junit:4.13'
+    testImplementation Libs.ASSERTJ_ANDROID
+    testImplementation Libs.ANNOTATION
+    testImplementation Libs.JUNIT
 
-    testImplementation 'org.mockito:mockito-core:3.3.0'
+    testImplementation Libs.MOCKITO
 }

--- a/snackengage-playrate/build.gradle
+++ b/snackengage-playrate/build.gradle
@@ -1,15 +1,18 @@
+import static org.ligi.snackengage.Dependencies.Android
+import static org.ligi.snackengage.Dependencies.Libs
+
 apply plugin: 'com.android.library'
 apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 28
-    buildToolsVersion "29.0.3"
+    compileSdkVersion Android.COMPILE_SDK_VERSION
+    buildToolsVersion Android.BUILD_TOOLS_VERSION
 
     defaultConfig {
-        minSdkVersion 14
-        targetSdkVersion 28
-        versionCode version_code
-        versionName version_name
+        minSdkVersion Android.MIN_SDK_VERSION
+        targetSdkVersion Android.TARGET_SDK_VERSION
+        versionCode Android.VERSION_CODE
+        versionName Android.VERSION_NAME
     }
     buildTypes {
         release {
@@ -30,6 +33,6 @@ android {
 
 dependencies {
     api project(':snackengage-core')
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation Libs.ANNOTATION
 }
 


### PR DESCRIPTION
# Description
+ Moving the dependency definitions and Android configuration values of all modules into the `buildSrc` folder allows to maintain them in a central location and reduce duplication.
+ Here is the associated [JitPack Build report](https://jitpack.io/com/github/johnjohndoe/snackengage/project-setup-buildsrc-b641ce4f8a-1/build.log).